### PR TITLE
Remove a transiant dependency

### DIFF
--- a/requirements/requirements_development.txt
+++ b/requirements/requirements_development.txt
@@ -7,7 +7,6 @@ flake8==3.8.4
 mccabe==0.6.1
 pathspec==0.8.1
 prometheus-flask-exporter==0.18.1
-pycodestyle==2.6.0
 pyflakes==2.2.0
 pytest==6.2.3
 pytest-datadir==1.3.1


### PR DESCRIPTION
This is used by flake so let flake manage the version is wants

```
 ERROR: Cannot install -r requirements/requirements_development.txt (line 6) and pycodestyle==2.6.0 because these package versions have conflicting dependencies.

The conflict is caused by:
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
    The user requested pycodestyle==2.6.0
    flake8 3.9.1 depends on pycodestyle<2.8.0 and >=2.7.0
```