### PR TITLE
Remove explicit pyflakes line

### DIFF
--- a/requirements/requirements_development.txt
+++ b/requirements/requirements_development.txt
@@ -7,7 +7,6 @@ flake8==3.8.4
 mccabe==0.6.1
 pathspec==0.8.1
 prometheus-flask-exporter==0.18.2
-pyflakes==2.2.0
 pytest==6.2.4
 pytest-datadir==1.3.1
 PyYAML==5.4.1


### PR DESCRIPTION
This module is depended on by flake8 and we should let it handle
the required version.

pipdeptree -

    flake8==3.8.4
      - mccabe [required: >=0.6.0,<0.7.0, installed: 0.6.1]
      - pycodestyle [required: >=2.6.0a1,<2.7.0, installed: 2.6.0]
      - pyflakes [required: >=2.2.0,<2.3.0, installed: 2.2.0]